### PR TITLE
Refactoring code duplication

### DIFF
--- a/src/reducers/signin.js
+++ b/src/reducers/signin.js
@@ -10,6 +10,14 @@
 
 import * as types from "../actions";
 
+function stateMap(loading, facebookLoading, error, facebookError, pending){
+	return {loading: loading,
+			facebookLoading: facebookLoading,
+			error: error,
+			facebookError: facebookError,
+			pending: pending};
+}
+
 const signin = (state = {
   loading: false,
   facebookLoading: false,
@@ -18,71 +26,22 @@ const signin = (state = {
 }, action) => {
   switch (action.type) {
   case types.FACEBOOK_SIGNIN_INITIATED:
-    return Object.assign({}, state, {
-      loading: false,
-      facebookLoading: true,
-      error: false,
-      facebookError: false
-    });
+    return Object.assign({}, state, stateMap(false,true,false,false,false));
   case types.FACEBOOK_SIGNIN_SUCCESSFUL:
-    return Object.assign({}, state, {
-      loading: false,
-      facebookLoading: false,
-      error: false,
-      facebookError: false
-    });
+    return Object.assign({}, state, stateMap(false,false,false,false,false));
   case types.FACEBOOK_SIGNIN_FAILED:
-    return Object.assign({}, state, {
-      loading: false,
-      facebookLoading: false,
-      error: false,
-      facebookError: action.errorCode
-    });
+    return Object.assign({}, state, stateMap(false,false,false,action.errorCode,false));
   case types.SIGNIN_INITIATED:
-    return Object.assign({}, state, {
-      loading: false,
-      pending: true,
-      facebookLoading: false,
-      error: false,
-    });
+    return Object.assign({}, state, stateMap(false,false,false,false,true));
   case types.SIGNIN_ERROR:
-    return Object.assign({}, state, {
-      loading: false,
-      pending: false,
-      facebookLoading: false,
-      error: action.data,
-    });
+    return Object.assign({}, state, stateMap(false,false,action.data,false,false));
   case types.CREATEUSER_INITIATED:
-    return Object.assign({}, state, {
-      loading: false,
-      pending: true,
-      facebookLoading: false,
-      error: false,
-    });
+    return Object.assign({}, state, stateMap(false,false,false,false,true));
   case types.CREATEUSER_ERROR:
-    return Object.assign({}, state, {
-      loading: false,
-      pending: false,
-      facebookLoading: false,
-      error: action.data,
-    });
-
-
-
-
-
-
-
+    return Object.assign({}, state, stateMap(false,false,action.data,false,false));
   default:
     return state;
   }
 };
 
 export default signin;
-
-
-
-
-
-
-


### PR DESCRIPTION
Created a function called stateMap that returns a map which was being used in all cases of the switch, reducing the code duplication of signin.js. 

Improved from D to A on Codeclimate.

https://codeclimate.com/github/gutioliveira/polisClientAdmin