### PR TITLE
Dockerize dgps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 ### SublimeText ###
 *.sublime-workspace
 
+*~
+*#
+env_dev
+
+
 ### OSX ###
 .DS_Store
 .AppleDouble

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,45 @@
-FROM node:10.15.0
+FROM node:6.10.3
 
-RUN npm install -g gulp
-RUN npm install gulp
-RUN npm link gulp
+# sudo docker container kill polis-client-admin; sudo docker container rm polis-client-admin; sudo docker image build -t polis-client-admin:1.0 .
 
-ADD package*.json .
-RUN npm install
+# sudo docker container kill polis-client-admin
+# sudo docker container rm polis-client-admin
+# sudo docker image build -t polis-client-admin:1.0 .
+# sudo docker container run --network="host" --publish 5001:5001 --detach --name polis-client-admin polis-client-admin:1.0
+# sudo docker logs polis-client-admin
+# --network="host" 
 
-ADD polis.config.template.js polis.config.js
+ARG host=localhost
+ARG port=5002
 
-ADD . .
+ARG static_files_host=localhost
+ARG static_files_port=5001
 
-RUN gulp dist
+ARG static_files_admin_host=localhost
+ARG static_files_admin_port=5002
+
+ARG postgres_host=localhost
+ARG postgres_port=5432
+ARG postgres_uid=postgres
+ARG postgres_pwd=postgres
+ARG postgres_db=polis-dev
+
+ENV DOMAIN_OVERRIDE ${host}:${port}
+ENV PORT ${port}
+
+ENV STATIC_FILES_HOST ${static_files_host}
+ENV STATIC_FILES_PORT ${static_files_port}
+ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g gulp && \
+    npm install
+
+EXPOSE ${port}
+
+#CMD npm start
+
+CMD [ "node", "dev-server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY . .
 
 #CMD npm start
 
-CMD [ "node", "dev-server.js" ]
+CMD node dev-server.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,36 +9,16 @@ FROM node:6.10.3
 # sudo docker logs polis-client-admin
 # --network="host" 
 
-ARG host=localhost
-ARG port=5002
-
-ARG static_files_host=localhost
-ARG static_files_port=5001
-
-ARG static_files_admin_host=localhost
-ARG static_files_admin_port=5002
-
-ARG postgres_host=localhost
-ARG postgres_port=5432
-ARG postgres_uid=postgres
-ARG postgres_pwd=postgres
-ARG postgres_db=polis-dev
-
-ENV DOMAIN_OVERRIDE ${host}:${port}
-ENV PORT ${port}
-
-ENV STATIC_FILES_HOST ${static_files_host}
-ENV STATIC_FILES_PORT ${static_files_port}
-ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
-
 WORKDIR /app
 
-COPY . .
+COPY *.json ./
 
 RUN npm install -g gulp && \
     npm install
 
 EXPOSE ${port}
+
+COPY . .
 
 #CMD npm start
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM node:6.10.3
 
-# sudo docker container kill polis-client-admin; sudo docker container rm polis-client-admin; sudo docker image build -t polis-client-admin:1.0 .
-
-# sudo docker container kill polis-client-admin
-# sudo docker container rm polis-client-admin
-# sudo docker image build -t polis-client-admin:1.0 .
-# sudo docker container run --network="host" --publish 5001:5001 --detach --name polis-client-admin polis-client-admin:1.0
-# sudo docker logs polis-client-admin
-# --network="host" 
-
 WORKDIR /app
 
 COPY *.json ./

--- a/dev-server.js
+++ b/dev-server.js
@@ -66,11 +66,11 @@ app.get('*', function(req, res) {
   res.status(200).send(html);
 });
 
-app.listen(5002, '0.0.0.0', function(err) {
+app.listen(polisConfig.ADMIN_PORT, polisConfig.ADMIN_HOST, function(err) {
   if (err) {
     console.log("error", err);
     return;
   }
 
-  console.log('Listening at http://localhost:5002');
+  console.log('Listening at http://'+polisConfig.ADMIN_HOST+':'+polisConfig.ADMIN_PORT);
 });


### PR DESCRIPTION
This is the second of 4 pull requests to enable pol-is to run in dev mode using docker-compose. To see all 4 pull requests working together, please follow the instructions at https://github.com/pol-is/polis-issues/issues/125. 

1.	This request changes the `Dockerfile` to run in dev mode instead of production mode. For people getting started with pol-is, this might be a better choice. 
2.	This request makes minor changes to `.gitignore`.
3.	This request reverts to node 6.10.3. node 10.15.0 was not working in dev mode. 
4.	This request modifies `dev-server.js` to enable it to run in a separate container with a unique IP address. 