### PR TITLE
Introduce empty polis.config for development

### DIFF
--- a/x
+++ b/x
@@ -1,2 +1,3 @@
 . ${NVM_DIR}/nvm.sh
+touch polis.config
 nvm run `node ./bin/printNodeVersion` dev-server.js


### PR DESCRIPTION
If I strictly follow the current instructions in the README, I get this error:

    Error: Cannot find module './polis.config'

By adding this line, we make the out of the box dev experience slightly nicer.